### PR TITLE
Add JSON-LD structured data (TechArticle + BreadcrumbList)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,48 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        "headline": "{{ page.title | default: site.title }}",
+        "description": "{{ page.description | default: site.description }}",
+        "url": "{{ page.url | absolute_url }}",
+        "datePublished": "{{ page.date | default: site.time | date_to_xmlschema }}",
+        "dateModified": "{{ site.time | date_to_xmlschema }}",
+        "author": {
+          "@type": "Organization",
+          "name": "Quillship Docs (WTD 2026 demo)"
+        },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "{{ site.title }}",
+          "url": "{{ '/' | absolute_url }}"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "{{ '/' | absolute_url }}"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "{{ page.title | default: page.url }}",
+            "item": "{{ page.url | absolute_url }}"
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

Adds Schema.org JSON-LD structured data to the site layout for improved AI discoverability and search engine understanding.

### Changes
- **TechArticle schema**: Provides machine-readable metadata about each doc page (headline, description, author, dates, parent website)
- **BreadcrumbList schema**: Describes navigation hierarchy (Home → current page)
- Both schemas use Liquid templating to dynamically populate per-page data

### Impact
This addresses the **Structured Data** category flagged by the audit tool, which previously scored 0/20. Once deployed, AI search engines (Perplexity, Claude, ChatGPT) and traditional search engines will better understand:
- That these are technical articles (not blog posts or general content)
- The site hierarchy and navigation structure
- Proper attribution and metadata for citations

### Testing Plan
- [ ] Verify GitHub Pages builds successfully
- [ ] View source on deployed page to confirm JSON-LD renders correctly
- [ ] Run audit tool at https://dzg557ngeo1lr.cloudfront.net/ against deployed site
- [ ] Optionally validate JSON-LD at https://validator.schema.org/

Fixes #19