### PR TITLE
Add HTML head metadata (OpenGraph, canonical, markdown alternate)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,19 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   <link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="{{ page.url | absolute_url }}">
+
+  <!-- Markdown alternate (helps AI coding agents discover the .md source) -->
+  {% assign md_url = page.path | replace: '.html', '.md' %}
+  <link rel="alternate" type="text/markdown" href="{{ '/' | append: md_url | absolute_url }}">
+
+  <!-- OpenGraph metadata -->
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="{{ page.title | default: site.title }}">
+  <meta property="og:description" content="{{ page.description | default: site.description }}">
+  <meta property="og:url" content="{{ page.url | absolute_url }}">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

Adds critical HTML head metadata to improve search engine optimization, AI discoverability, and social media sharing.

### Changes

**1. Canonical URL tag**
- Prevents duplicate content indexing issues
- Tells search engines the official URL for each page
- Example: `<link rel="canonical" href="https://...">`

**2. Markdown alternate link**
- Tells AI coding agents (GitHub Copilot, Cursor, Claude Code) where to fetch raw `.md` source
- Cutting-edge AI-readiness feature
- Example: `<link rel="alternate" type="text/markdown" href=".../*.md">`

**3. OpenGraph metadata**
- Controls how links appear when shared on Slack, Discord, Twitter, LinkedIn
- Includes: `og:type`, `og:title`, `og:description`, `og:url`
- Without these, shared links show generic/incorrect previews

### Implementation

All tags use Liquid templating (`{{ page.title }}`, `{{ page.url | absolute_url }}`) to dynamically populate per-page values, ensuring each page gets customized metadata.

### Impact

This addresses HTML head metadata signals flagged by the audit tool. Combined with PR #26 (JSON-LD), these changes provide comprehensive metadata coverage for both AI systems and traditional search engines.

### Testing Plan

- [ ] Verify GitHub Pages builds successfully
- [ ] View source on deployed pages to confirm all tags render with real values
- [ ] Test OpenGraph by sharing a doc link in Slack/Discord
- [ ] Run audit tool at https://dzg557ngeo1lr.cloudfront.net/

Fixes #18